### PR TITLE
Implemented persistent user session handling with Firebase Auth

### DIFF
--- a/fixora/lib/auth/auth_gate.dart
+++ b/fixora/lib/auth/auth_gate.dart
@@ -3,7 +3,6 @@ import 'package:firebase_auth/firebase_auth.dart';
 
 import 'auth_service.dart';
 import '../pages/landing_page/landing.dart';
-import '../widgets/user_dashboard.dart';
 import '../pages/user_dashboard/dashboard.dart';
 
 /// Simple AuthGate that listens to `authStateChanges` and returns
@@ -35,8 +34,8 @@ class AuthGate extends StatelessWidget {
           return const LandingPage();
         }
 
-        // Signed in - show user dashboard
-        return UserDashboard(email: user.email ?? '');
+        // Signed in - show dashboard screen (which will fetch the username)
+        return const DashboardScreen();
       },
     );
   }

--- a/fixora/lib/auth/auth_service.dart
+++ b/fixora/lib/auth/auth_service.dart
@@ -12,6 +12,17 @@ class AuthService {
 
   User? get currentUser => _auth.currentUser;
 
+  /// Returns the username stored in Firestore for the current user, if any
+  Future<String?> getUsernameForCurrentUser() async {
+    final user = _auth.currentUser;
+    if (user == null) return null;
+    final doc = await _firestore.collection('users').doc(user.uid).get();
+    if (!doc.exists) return null;
+    final data = doc.data();
+    if (data == null) return null;
+    return (data['username'] as String?) ?? null;
+  }
+
   /// Validates password according to requirements:
   /// 1. At least 6 characters
   /// 2. Starts with a capital letter


### PR DESCRIPTION
### **User description**
This PR implements persistent user session management in the Flutter application using Firebase Authentication. The goal is to enhance user experience by ensuring that authenticated users remain logged in across app restarts without needing to re-enter their credentials.


___

### **PR Type**
Enhancement


___

### **Description**
- Refactored dashboard to fetch and display username from Firestore

- Integrated ThemeProvider for centralized theme management

- Improved logout flow with confirmation dialog

- Removed local theme state and hardcoded theme methods


___

### Diagram Walkthrough


```mermaid
flowchart LR
  AuthGate["AuthGate"] -- "routes to" --> DashboardScreen["DashboardScreen"]
  DashboardScreen -- "fetches username via" --> AuthService["AuthService.getUsernameForCurrentUser()"]
  AuthService -- "queries" --> Firestore["Firestore users collection"]
  DashboardScreen -- "toggles theme via" --> ThemeProvider["ThemeProvider"]
  DashboardScreen -- "signs out via" --> AuthService
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auth_gate.dart</strong><dd><code>Simplify dashboard routing to use DashboardScreen</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fixora/lib/auth/auth_gate.dart

<ul><li>Removed import of <code>UserDashboard</code> widget<br> <li> Changed dashboard routing from <code>UserDashboard(email: user.email)</code> to <br><code>DashboardScreen()</code><br> <li> Updated comment to reflect that dashboard fetches username internally</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S61-1225-ChronoByte-FlutterAndFireBase-Fixora/pull/34/files#diff-20b3dab405c42500d9bf5cc69843e4ad962cdaa7b5ccda687ac939ff072f5ced">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>auth_service.dart</strong><dd><code>Add method to fetch username from Firestore</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fixora/lib/auth/auth_service.dart

<ul><li>Added <code>getUsernameForCurrentUser()</code> method to fetch username from <br>Firestore<br> <li> Method queries the <code>users</code> collection document for current user's UID<br> <li> Returns username string or null if user/document doesn't exist</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S61-1225-ChronoByte-FlutterAndFireBase-Fixora/pull/34/files#diff-7ca4fb5045a60c0c8fa095cb077a49440f1b75ed3ed70fcbfa4228b8b8c50bfb">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dashboard.dart</strong><dd><code>Refactor dashboard with Firestore username and ThemeProvider</code></dd></summary>
<hr>

fixora/lib/pages/user_dashboard/dashboard.dart

<ul><li>Added imports for <code>Provider</code> and <code>ThemeProvider</code> for theme management<br> <li> Replaced local <code>isDark</code> state with username loading state (<code>_username</code>, <br><code>_loadingUsername</code>)<br> <li> Implemented <code>_loadUsername()</code> to fetch username from Firestore on init<br> <li> Refactored <code>_onMenuSelected()</code> to use <code>ThemeProvider.toggleTheme()</code> <br>instead of local state<br> <li> Added logout confirmation dialog with proper navigation cleanup<br> <li> Removed <code>MaterialApp</code> wrapper and local theme methods (<code>_lightTheme()</code>, <br><code>_darkTheme()</code>)<br> <li> Added greeting section displaying username or loading indicator<br> <li> Updated color references to use <code>Theme.of(context)</code> for dynamic theming<br> <li> Improved UI consistency with theme-aware colors throughout</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S61-1225-ChronoByte-FlutterAndFireBase-Fixora/pull/34/files#diff-0f0c1e679cd5c3be31296c1f4f2056bd35b00cb2a79aa3f4a8d50b40db5de6ea">+122/-108</a></td>

</tr>
</table></td></tr></tbody></table>

</details>

___

