### PR TITLE
Implemented multi-screen navigation using Navigator and routes

### DIFF
--- a/fixora/lib/main.dart
+++ b/fixora/lib/main.dart
@@ -54,11 +54,11 @@ class MyApp extends StatelessWidget {
           themeMode: themeProvider.themeMode,
           initialRoute: '/',
           routes: {
-            // '/': (context) => const HomePage(),
-            // '/': (context) => const AuthGate(),
+            // Use AuthGate at the root so auth state determines initial screen
+            '/': (context) => const AuthGate(),
             '/signup': (context) => const SignupPage(),
             '/login': (context) => const LoginPage(),
-            '/': (context) => const BottomNavbarPage(),
+            '/home': (context) => const BottomNavbarPage(),
             '/report': (context) => const RaiseIssuePage(),
             '/track': (context) => const TrackComplaintPage(),
             '/profile': (context) => const ProfilePage(),

--- a/fixora/lib/pages/landing_page/landing.dart
+++ b/fixora/lib/pages/landing_page/landing.dart
@@ -5,9 +5,47 @@ import 'steps_section.dart';
 import 'report_now_section.dart';
 import 'footer_section.dart';
 import '../../widgets/animated_section.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../../auth/auth_service.dart';
 
-class LandingPage extends StatelessWidget {
+class LandingPage extends StatefulWidget {
   const LandingPage({super.key});
+
+  @override
+  _LandingPageState createState() => _LandingPageState();
+}
+
+class _LandingPageState extends State<LandingPage> {
+  @override
+  void initState() {
+    super.initState();
+    _checkAuthAndRedirect();
+  }
+
+  Future<void> _checkAuthAndRedirect() async {
+    final user = AuthService.instance.currentUser;
+    if (user == null) return;
+
+    try {
+      final doc = await FirebaseFirestore.instance.collection('users').doc(user.uid).get();
+      final role = (doc.data()?['role']) as String?;
+      final email = user.email ?? '';
+      final isAdmin = (role == 'admin') || email.toLowerCase().endsWith('@fixoradmin.com');
+
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        Navigator.pushReplacementNamed(context, isAdmin ? '/admin' : '/home');
+      });
+    } catch (e) {
+      final email = user.email ?? '';
+      final isAdmin = email.toLowerCase().endsWith('@fixoradmin.com');
+
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        Navigator.pushReplacementNamed(context, isAdmin ? '/admin' : '/home');
+      });
+    }
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/fixora/lib/pages/landing_page/report_now_section.dart
+++ b/fixora/lib/pages/landing_page/report_now_section.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import '../../auth/login_page.dart';
 
 class ReportNowSection extends StatelessWidget {
   const ReportNowSection({super.key});
@@ -46,10 +45,7 @@ class ReportNowSection extends StatelessWidget {
                 ),
               ),
               onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (context) => const LoginPage()),
-                );
+                Navigator.pushNamed(context, '/login');
               },
               child: const Text(
                 "Submit Complaint",


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Implemented named route navigation system with AuthGate root route

- Added authentication-aware navigation with role-based routing

- Converted HeaderSection and LandingPage to StatefulWidget for auth checks

- Enhanced header menu with PopupMenuButton for navigation options


___

### Diagram Walkthrough


```mermaid
flowchart LR
  AuthGate["AuthGate<br/>Root Route"]
  AuthCheck["Auth State<br/>Check"]
  AdminRoute["/admin<br/>Admin Dashboard"]
  HomeRoute["/home<br/>User Dashboard"]
  LoginRoute["/login<br/>Login Page"]
  
  AuthGate -- "Check User" --> AuthCheck
  AuthCheck -- "Is Admin" --> AdminRoute
  AuthCheck -- "Is User" --> HomeRoute
  AuthCheck -- "No Auth" --> LoginRoute
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.dart</strong><dd><code>Configure named routes with AuthGate root</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fixora/lib/main.dart

<ul><li>Changed root route from BottomNavbarPage to AuthGate for auth-based <br>navigation<br> <li> Moved BottomNavbarPage to '/home' route instead of '/'<br> <li> Added comments explaining AuthGate usage at root level</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S61-1225-ChronoByte-FlutterAndFireBase-Fixora/pull/51/files#diff-3549ff7e94b478e86db0e90a8960895735c88eac4f222f09f1f154bfb4cad054">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>header_section.dart</strong><dd><code>Add popup menu with auth-aware dashboard navigation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fixora/lib/pages/landing_page/header_section.dart

<ul><li>Converted HeaderSection from StatelessWidget to StatefulWidget<br> <li> Added PopupMenuButton replacing simple menu icon with navigation <br>options<br> <li> Implemented _goToDashboard method with role-based routing logic<br> <li> Replaced direct Navigator.push with named route navigation<br> <li> Added Firebase Firestore integration for user role checking</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S61-1225-ChronoByte-FlutterAndFireBase-Fixora/pull/51/files#diff-f795e5b3ceab08a2121f012b048960e7c6bdabf3df65f6000b0cb58c696b3edc">+99/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>landing.dart</strong><dd><code>Add auth check with automatic dashboard redirect</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fixora/lib/pages/landing_page/landing.dart

<ul><li>Converted LandingPage from StatelessWidget to StatefulWidget<br> <li> Added initState with _checkAuthAndRedirect method for auth checks<br> <li> Implemented automatic redirect to dashboard for authenticated users<br> <li> Added role-based routing logic to determine admin vs user dashboard<br> <li> Integrated Firebase Firestore for user role verification</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S61-1225-ChronoByte-FlutterAndFireBase-Fixora/pull/51/files#diff-cfe6581297280bb445f9f94256f172c3801f700ed64c9a8dac5e7d3c421f4480">+39/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>report_now_section.dart</strong><dd><code>Update navigation to use named routes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fixora/lib/pages/landing_page/report_now_section.dart

<ul><li>Removed direct import of LoginPage<br> <li> Replaced Navigator.push with named route navigation to '/login'</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S61-1225-ChronoByte-FlutterAndFireBase-Fixora/pull/51/files#diff-c93321619d9671786b24332c80f29c2a1bcbee0cf75ea0d60fa305b191c5f930">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

